### PR TITLE
docs: add Docker usage instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,34 @@
 
 ## Usage
 
+
 ```shell
 cd src
 python do_on_fix.py --config example.yml # Remember fill out the config.
+```
+
+## Docker Usage
+
+Build the docker image:
+
+```shell
+docker build -t patch-backporting .
+```
+
+Run the container:
+
+```shell
+# Ensure you mount the necessary directories (code, config, datasets)
+# Example: assuming config.yml is in current dir and datasets are in /data
+docker run --rm -v $(pwd):/app/src -v /path/to/dataset:/path/to/dataset patch-backporting python backporting.py --config config.yml
+```
+
+Alternatively, you can use the interactive mode to execute scripts inside the container:
+
+```shell
+docker run --rm -it -v $(pwd):/app/src -v /path/to/dataset:/path/to/dataset patch-backporting /bin/bash
+# Inside the container
+python backporting.py --config config.yml
 ```
 
 ## Config structure
@@ -40,4 +65,5 @@ patch_dataset_dir: ~/backports/patch_dataset/libtiff/CVE-2023-3576/ # path to yo
 #     └─────────────►│   ├────────────► ??                    
 #                    └───┘                       
 ```
+
 


### PR DESCRIPTION
This PR adds a "Docker Usage" section to the documentation to guide users on how to build and run the `RetroPatch` environment.